### PR TITLE
Fix NRE when grabbing a stateful part from a container.

### DIFF
--- a/Plugin/KASModuleGrab.cs
+++ b/Plugin/KASModuleGrab.cs
@@ -290,7 +290,8 @@ namespace KAS
             }
 
             //Destroy joint to avoid buggy eva move
-            this.part.attachJoint.DestroyJoint();
+            if (this.part.attachJoint)
+                this.part.attachJoint.DestroyJoint();
             
             this.part.rigidbody.velocity = kerbalEvaVessel.rootPart.rigidbody.velocity;
 


### PR DESCRIPTION
Unlike Destroy(foo), foo.DestroyJoint() will crash if foo is null.
