### PR TITLE
Added ModuleManager sanity checks

### DIFF
--- a/MM_Squad.cfg
+++ b/MM_Squad.cfg
@@ -1,4 +1,4 @@
-@PART[KAS_ContainerBay1]:FOR[KAS]
+@PART[KAS_ContainerBay1]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -13,7 +13,7 @@
     }
 }
 
-@PART[linearRcs]:FOR[KAS]
+@PART[linearRcs]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -33,7 +33,7 @@
     }
 }
 
-@PART[RCSBlock]:FOR[KAS]
+@PART[RCSBlock]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -49,7 +49,7 @@
     }
 }
 
-@PART[roverWheel2]:FOR[KAS]
+@PART[roverWheel2]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -65,7 +65,7 @@
     }
 }
 
-@PART[batteryPack]:FOR[KAS]
+@PART[batteryPack]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -82,7 +82,7 @@
     }
 }
 
-@PART[spotLight1]:FOR[KAS]
+@PART[spotLight1]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -98,7 +98,7 @@
     }
 }
 
-@PART[spotLight2]:FOR[KAS]
+@PART[spotLight2]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -114,7 +114,7 @@
     }
 }
 
-@PART[ladder1]:FOR[KAS]
+@PART[ladder1]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -130,7 +130,7 @@
     }
 }
 
-@PART[telescopicLadder]:FOR[KAS]
+@PART[telescopicLadder]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -146,7 +146,7 @@
     }
 }
 
-@PART[telescopicLadderBay]:FOR[KAS]
+@PART[telescopicLadderBay]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -162,7 +162,7 @@
     }
 }
 
-@PART[solarPanels1]:FOR[KAS]
+@PART[solarPanels1]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -178,7 +178,7 @@
     }
 }
 
-@PART[solarPanels2]:FOR[KAS]
+@PART[solarPanels2]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -194,7 +194,7 @@
     }
 }
 
-@PART[solarPanels3]:FOR[KAS]
+@PART[solarPanels3]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -210,7 +210,7 @@
     }
 }
 
-@PART[solarPanels4]:FOR[KAS]
+@PART[solarPanels4]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -226,7 +226,7 @@
     }
 }
 
-@PART[solarPanels5]:FOR[KAS]
+@PART[solarPanels5]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -241,7 +241,7 @@
         attachSendMsgOnly = False}
 }
 
-@PART[rtg]:FOR[KAS]
+@PART[rtg]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -257,7 +257,7 @@
     }
 }
 
-@PART[seatExternalCmd]:FOR[KAS]
+@PART[seatExternalCmd]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -273,7 +273,7 @@
     }
 }
 
-@PART[smallRadialEngine]:FOR[KAS]
+@PART[smallRadialEngine]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -289,7 +289,7 @@
     }
 }
 
-@PART[radialEngineMini]:FOR[KAS]
+@PART[radialEngineMini]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -305,7 +305,7 @@
     }
 }
 
-@PART[radialRCSTank]:FOR[KAS]
+@PART[radialRCSTank]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -322,7 +322,7 @@
     }
 }
 
-@PART[xenonTankRadial]:FOR[KAS]
+@PART[xenonTankRadial]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -339,7 +339,7 @@
     }
 }
 
-@PART[strutCube]:FOR[KAS]
+@PART[strutCube]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -355,7 +355,7 @@
     }
 }
 
-@PART[sensorAccelerometer]:FOR[KAS]
+@PART[sensorAccelerometer]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -372,7 +372,7 @@
     }
 }
 
-@PART[sensorBarometer]:FOR[KAS]
+@PART[sensorBarometer]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -389,7 +389,7 @@
     }
 }
 
-@PART[sensorGravimeter]:FOR[KAS]
+@PART[sensorGravimeter]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -406,7 +406,7 @@
     }
 }
 
-@PART[sensorThermometer]:FOR[KAS]
+@PART[sensorThermometer]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -423,7 +423,7 @@
     }
 }
 
-@PART[commDish]:FOR[KAS]
+@PART[commDish]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -439,7 +439,7 @@
     }
 }
 
-@PART[mediumDishAntenna]:FOR[KAS]
+@PART[mediumDishAntenna]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -455,7 +455,7 @@
     }
 }
 
-@PART[longAntenna]:FOR[KAS]
+@PART[longAntenna]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {
@@ -471,7 +471,7 @@
     }
 }
 
-@PART[parachuteRadial]:FOR[KAS]
+@PART[parachuteRadial]:HAS[!MODULE[KASModuleGrab]]:FOR[KAS]
 {
     MODULE
     {


### PR DESCRIPTION
This would prevent a bug we had over at RemoteTech, where ModuleManager issues or conflicting 3rd-party patches could cause key modules to get added to parts twice.
