### PR TITLE
Fix #297

### DIFF
--- a/Source/modules/KASLinkSourceBase.cs
+++ b/Source/modules/KASLinkSourceBase.cs
@@ -241,7 +241,7 @@ public class KASLinkSourceBase : AbstractLinkPeer,
     AsyncCall.CallOnEndOfFrame(
         this,
         () => {
-          if (isLinked && vessel != originator.vessel) {
+          if (isLinked && vessel == originator.vessel) {
             HostedDebugLog.Fine(
                 this,
                 "Coupling has not been restored, resetting the docking mode: {0} <=> {1}",


### PR DESCRIPTION
Checking if the vessel is linked and that they are the same vessel as the decouple originator was calling linkJoint.SetCoupleOnLinkMode(false) which made the check pass in AbstractJoint.SetCoupleOnLinkMode() causing it to call decoupleParts() incorrectly. 

Actions such as "extend cable" in the context menu follows different code paths before it calls linkJoint.SetCoupleOnLinkMode(false) so this change shouldn't affect them. The issue seems to be specifically with how the code was handling KSP's onDecouple event. 